### PR TITLE
✨ Solve : [11066]파일 합치기

### DIFF
--- a/jiyoung/week5/[11066]파일 합치기.java
+++ b/jiyoung/week5/[11066]파일 합치기.java
@@ -1,0 +1,33 @@
+import java.util.*;
+import java.io.*;
+
+class Main {
+  public static void main(String[] args) throws IOException {
+    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+    StringTokenizer st;
+    int t = Integer.parseInt(br.readLine());
+
+    while(t-->0){
+      int k = Integer.parseInt(br.readLine());
+      int[] files = new int[k+1]; // 파일 누적합
+      int[][] dp = new int[k+1][k+1];
+
+      st = new StringTokenizer(br.readLine(), " ");
+      for(int i=1; i<k+1; i++){
+        int temp = Integer.parseInt(st.nextToken());
+        files[i] = temp + files[i-1];
+      }
+
+      for(int i=1; i<k; i++){ // 파일의 조각 길이
+        for(int start=1; start+i<=k; start++){
+          int end = start + i;
+          dp[start][end] = Integer.MAX_VALUE;
+          for(int m=start; m<end; m++){ // 파일을 나눌 지점
+            dp[start][end] = Math.min(dp[start][end], dp[start][m]+dp[m+1][end]+files[end]-files[start-1]);
+          }
+        }
+      }
+      System.out.println(dp[1][k]);
+    }
+  }
+}


### PR DESCRIPTION
- Issue : #1 

## 🧐 풀이 과정
처음에는 연속된 페이지만 합칠 수 있다는 사실을 간과해 [파일 합치기3 문제](https://www.acmicpc.net/problem/13975)를 풀어버렸다.
당연하게도 우선순위 큐로 풀면 안 된다.. 문제의 차이점을 인지하고 다시 어떻게 DP를 활용할지 고민했다.

배열을 어떤 방식으로 사용하고 관리할지가 가장 어려웠다.
1. `files`라는 배열로 페이지의 **누적 합**을 관리해주었다.
2. `dp`라는 배열로 start부터 end까지의 파일을 합치는데 드는 **최소 비용**을 저장해주었다.

맨 처음에 start부터 end를 한 덩어리로 보고, 거꾸로 잘라내면서 최소가 되는 값을 찾도록 했다.
for문을 중첩되게 3번 사용했다.
1. 파일의 조각 길이
2. 파일의 시작 인덱스를 설정
3. 파일을 나눌 지점

`dp[start][m]` : start부터 m까지의 파일을 합치는데 드는 최소 비용
`dp[m+1][end]` : m+1부터 end까지의 파일을 합치는데 드는 최소 비용
`files[end] - files[start-1]` : start부터 end까지의 파일 크기의 합
➡️ `dp[start][m] + dp[m+1][end] + files[end] - files[start-1]` : 현재 start부터 end까지의 파일을 합치는데 드는 비용

결과적으로 `dp[start][end]`에는 각 파일 조각을 합치는데 드는 최소 비용이 저장된다.
`dp[1][k]`에는 모든 파일을 합치는데 드는 최소 비용이 저장된다.

## 🤗 완성 코드

```java
import java.util.*;
import java.io.*;

class Main {
  public static void main(String[] args) throws IOException {
    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
    StringTokenizer st;
    int t = Integer.parseInt(br.readLine());

    while(t-->0){
      int k = Integer.parseInt(br.readLine());
      int[] files = new int[k+1]; // 파일 누적합
      int[][] dp = new int[k+1][k+1];

      st = new StringTokenizer(br.readLine(), " ");
      for(int i=1; i<k+1; i++){
        int temp = Integer.parseInt(st.nextToken());
        files[i] = temp + files[i-1];
      }

      for(int i=1; i<k; i++){ // 파일의 조각 길이
        for(int start=1; start+i<=k; start++){
          int end = start + i;
          dp[start][end] = Integer.MAX_VALUE;
          for(int m=start; m<end; m++){ // 파일을 나눌 지점
            dp[start][end] = Math.min(dp[start][end], dp[start][m]+dp[m+1][end]+files[end]-files[start-1]);
          }
        }
      }
      System.out.println(dp[1][k]);
    }
  }
}
```